### PR TITLE
Add JWT token check in state query param [AM-869]

### DIFF
--- a/helpers/jwt.js
+++ b/helpers/jwt.js
@@ -24,11 +24,24 @@ exports.parse = function (req) {
   // in just in case - won't hurt anything
   const authHeader = req.headers && (req.headers.Authorization || req.headers.authorization);
   const authQuery = req.query.jwt_token;
+  // add a check for an embedded jwt_token in the state query param also (oauth spec)
+  const stateQuery = req.query.state;
 
   if (authHeader)
     return authHeader.split('Bearer ')[1];
   if (authQuery)
     return authQuery;
+  if (stateQuery) {
+    // for auth purposes, stringified json
+    try {
+      const obj = JSON.parse(stateQuery);
+      if (obj.jwt_token) {
+        return obj.jwt_token;
+      }
+    } catch (e) {
+      console.error(`state param did not parse as JSON ${e}`);
+    }
+  }
 
   throw new Error('No JWT token provided.');
 };


### PR DESCRIPTION
Per the OAuth 2.0 spec, it is better practice to pass required information around via the `state` query parameter rather than other params.

This change will add an additional check for a JWT token in the state parameter.

Use:

1. Client makes initial authorization request to OAuth 2.0 provider with `state={content}` as one of the params

2. Following successful auth, provider redirects to a callback url with `state={content}` as a query param unmodified from the initial request

By passing the `jwt_token` content in the state param, it comes through unmodified and does not interfere with provider's systems.

The state parameter is being sent as a stringified JSON object in order to accommodate other state values that may or may not be required by future OAuth implementations. 